### PR TITLE
Remove unnecessary code

### DIFF
--- a/src/main/java/com/crowsofwar/avatar/common/entity/EntityShield.java
+++ b/src/main/java/com/crowsofwar/avatar/common/entity/EntityShield.java
@@ -87,7 +87,7 @@ public abstract class EntityShield extends AvatarEntity {
 	 * Handles hovering logic to make the owner hover. Preconditions (not in water, owner
 	 * present, etc) are handled by the caller
 	 */
-	private void handleHovering() {
+	protected void handleHovering() {
 
 		if (getOwner() != null) {
 			getOwner().fallDistance = 0;


### PR DESCRIPTION
This method already exists in EntityShield, but is private. Proposal: change it to protected and remove redundant code.